### PR TITLE
ダッシュボード画面の更新

### DIFF
--- a/app/assets/style/style.scss
+++ b/app/assets/style/style.scss
@@ -75,9 +75,10 @@ a {
 .error {
   margin-top: 5rem;
   text-align: center;
-  &__btn {
-    margin-top: 1rem;
-  }
+}
+
+.error__btn {
+  margin-top: 1rem;
 }
 
 .textMessage {
@@ -351,12 +352,15 @@ a {
 }
 
 .auth-area {
-  margin-top: 1rem;
-  margin-right: 1rem;
+  display: flex;
+  // margin-top: 1rem;
+  // margin-right: 1rem;
+  max-width: 1200px;
+  margin: 1rem auto 0;
 }
 
 .btn {
-  display: inline-block;
+  display: inline-flex;
   font-size: 1em;
   font-weight: bold;
   height: 38px;
@@ -368,9 +372,6 @@ a {
   border: 0;
   border-radius: 0.5em;
   transition: 0.4s;
-  &--center {
-    margin: 1rem auto 0;
-  }
   &--large {
     font-size: 3em;
   }
@@ -410,13 +411,8 @@ a {
   }
 }
 
+.sign-in,
 .sign-out {
-  display: block;
-  margin: 0 0 0 auto;
-}
-
-.edit-button {
-  display: block;
   margin: 0 0 0 auto;
 }
 
@@ -499,7 +495,15 @@ a {
 /* dashboard */
 .dashboard {
   display: flex;
-  flex-direction: row;
+  max-width: 1200px;
+  margin: 3rem auto 0;
+
+  @media screen and (max-width: $sm) {
+    .dashboard {
+      margin: 0;
+      padding: 2rem 1rem;
+    }
+  }
 
   &__nav {
     position: fixed;
@@ -524,15 +528,8 @@ a {
 
   &__content {
     padding-left: 200px;
+    padding-bottom: 5rem;
     width: 100%;
-  }
-
-  &__btn {
-    display: flex;
-    margin-top: 1rem;
-    &--center {
-      margin: 1rem auto 0;
-    }
   }
 
   &__title {
@@ -544,6 +541,20 @@ a {
   }
 }
 
+.dashboardArticleList__header {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.dashboardArticleList__body {
+  margin-top: 1rem;
+}
+
+// .dashboardEdit {
+
+// }
+
+// article
 .article {
   display: flex;
   justify-content: space-between;
@@ -722,6 +733,8 @@ a {
 }
 
 .articleEdit {
+  padding-bottom: 5rem;
+
   &__title {
     width: 100%;
     height: 2.5rem;
@@ -735,20 +748,6 @@ a {
     background-color: #fbfcff;
   }
 
-  &__toggleBtn {
-    justify-content: flex-end;
-    margin-top: 0.5rem;
-  }
-
-  &__btn {
-    display: flex;
-    margin-top: 1rem;
-  }
-
-  &__tagContainer {
-    margin-top: 1rem;
-  }
-
   &__tag {
     outline: 0;
     border-radius: 4px;
@@ -756,4 +755,23 @@ a {
     background-color: #fbfcff;
     margin-left: 0.3rem;
   }
+}
+
+.dashboardEdit__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 1rem;
+
+  :only-child {
+    text-align: right;
+  }
+}
+
+.dashboardEdit__btnWrapper {
+  display: flex;
+}
+
+.dashboardEdit__btn {
+  margin-left: 1rem;
 }

--- a/app/components/Article/ArticleEdit.vue
+++ b/app/components/Article/ArticleEdit.vue
@@ -1,20 +1,13 @@
 <template>
-  <section class="wrapper">
-    <div class="articleEdit">
-      <textarea
-        v-model="article.title"
-        placeholder="Title"
-        class="articleEdit__title"
-        maxlength="64"
-      />
-      <ToggleBtn
-        :toggle-btn="article.isPublished"
-        class="articleEdit__toggleBtn"
-        @toggle="updatePublishing"
-      >
-        公開する
-      </ToggleBtn>
-      <MarkdownEditor :plain-text="article.text" @input="setText" />
+  <section class="articleEdit">
+    <!-- TODO: 戻るボタンほしい -->
+    <textarea
+      v-model="article.title"
+      placeholder="Title"
+      class="articleEdit__title dashboardEdit__title"
+      maxlength="64"
+    />
+    <div class="dashboardEdit__head">
       <div class="articleEdit__tagContainer">
         <b>Tags:</b>
         <input
@@ -24,14 +17,24 @@
           placeholder="コンマ区切りで入力"
         />
       </div>
-      <button
-        class="articleEdit__btn btn btn--center"
-        :disabled="article.title === '' || tag === ''"
-        @click="updateArticle"
-      >
-        保存
-      </button>
+      <div class="dashboardEdit__btnWrapper">
+        <ToggleBtn
+          class="dashboardEdit__btn"
+          :toggle-btn="article.isPublished"
+          @toggle="updatePublishing"
+        >
+          公開する
+        </ToggleBtn>
+        <button
+          class="dashboardEdit__btn btn"
+          :disabled="article.title === '' || tag === ''"
+          @click="updateArticle"
+        >
+          保存
+        </button>
+      </div>
     </div>
+    <MarkdownEditor :plain-text="article.text" @input="setText" />
   </section>
 </template>
 

--- a/app/components/DashboardArticleList.vue
+++ b/app/components/DashboardArticleList.vue
@@ -1,8 +1,10 @@
 <template>
-  <section class="dashboard__content">
+  <section class="dashboard__content dashboardArticleList">
     <h1 class="dashboard__title">Articles</h1>
-    <button class="dashboard__btn btn" @click="addArticle">Add new</button>
-    <div class="dashboard__item">
+    <div class="dashboardArticleList__header">
+      <button class="btn" @click="addArticle">Add new</button>
+    </div>
+    <div class="dashboardArticleList__body">
       <DashboardArticle
         v-for="article in articles"
         :key="article.id"

--- a/app/components/DashboardArticleList.vue
+++ b/app/components/DashboardArticleList.vue
@@ -39,7 +39,7 @@ export default Vue.extend({
       // TODO: 型引数を渡す方がいい？
       const article = (await Apis.db.getOrderDocs(
         collectionPath,
-        'updatedDate',
+        'createdDate',
         'desc'
       )) as Article[]
 

--- a/app/components/DashboardGallery.vue
+++ b/app/components/DashboardGallery.vue
@@ -1,8 +1,10 @@
 <template>
   <section class="dashboard__content">
     <h3>Gallery Edit</h3>
-    <ImgUploader />
-    <button class="btn edit-button" @click="deleteImgList()">Delete</button>
+    <div class="dashboardEdit__head">
+      <ImgUploader />
+      <button class="btn" @click="deleteImgList()">Delete</button>
+    </div>
     <div class="gallery">
       <div v-if="imgList.length === 0">No Photos</div>
       <div

--- a/app/components/MarkdownEditor.vue
+++ b/app/components/MarkdownEditor.vue
@@ -81,7 +81,6 @@ export default Vue.extend({
   }
   &__content {
     padding: 0 0.5rem;
-    height: 50vh;
     overflow: scroll;
   }
 }
@@ -91,13 +90,13 @@ export default Vue.extend({
 
 textarea {
   width: 100%;
-  height: 50vh;
+  height: 100%;
   border: 0;
   padding: 0;
   outline: 0;
   resize: none;
   font-size: 16px;
-  line-height: inherit;
+  line-height: 1.9;
   background-color: #fbfcff;
 }
 </style>

--- a/app/components/MarkdownEditor.vue
+++ b/app/components/MarkdownEditor.vue
@@ -81,7 +81,6 @@ export default Vue.extend({
   }
   &__content {
     padding: 0 0.5rem;
-    overflow: scroll;
   }
 }
 .textEdit {

--- a/app/components/MarkdownPreview.vue
+++ b/app/components/MarkdownPreview.vue
@@ -14,90 +14,115 @@ export default Vue.extend({})
   margin-top: 0;
 }
 
-.markdown ::v-deep a {
-  color: var(--yellow);
+.markdown::v-deep {
+  line-height: 1.9;
 
-  &:hover {
-    text-decoration: underline;
+  a {
+    color: var(--yellow);
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
-}
 
-.markdown ::v-deep h1 {
-  margin-top: 2em;
-  border-bottom: 1px solid #ddd;
-}
+  h1 {
+    margin-top: 2em;
+    border-bottom: 1px solid #ddd;
+  }
 
-.markdown ::v-deep h2 {
-  margin-top: 2em;
-  border-bottom: 1px solid #ddd;
-}
+  h2 {
+    margin-top: 2em;
+    border-bottom: 1px solid #ddd;
+  }
 
-.markdown ::v-deep h3 {
-  margin-top: 1.5em;
-}
+  h3 {
+    margin-top: 1.5em;
+  }
 
-.markdown ::v-deep h4 {
-  margin-top: 1.5em;
-}
+  h4 {
+    margin-top: 1.5em;
+  }
 
-.markdown ::v-deep h5 {
-  margin-top: 1.5em;
-}
+  h5 {
+    margin-top: 1.5em;
+  }
 
-.markdown ::v-deep h6 {
-  font-size: 0.9rem;
-}
+  h6 {
+    font-size: 0.9rem;
+  }
 
-.markdown ::v-deep h1 + h2 {
-  margin-top: 1.5em;
-}
+  h1 + h2 {
+    margin-top: 1.5em;
+  }
 
-.markdown ::v-deep h2 + h3 {
-  margin-top: 1.5em;
-}
+  h2 + h3 {
+    margin-top: 1.5em;
+  }
 
-.markdown ::v-deep h3 + h4 {
-  margin-top: 1em;
-}
+  h3 + h4 {
+    margin-top: 1em;
+  }
 
-.markdown ::v-deep h4 + h5 {
-  margin-top: 1em;
-}
+  h4 + h5 {
+    margin-top: 1em;
+  }
 
-.markdown ::v-deep h5 + h6 {
-  margin-top: 1em;
-}
+  h5 + h6 {
+    margin-top: 1em;
+  }
 
-.markdown ::v-deep ul {
-  padding-left: 1.2em;
-  list-style-type: disc;
-}
+  p {
+    margin-top: 1.5rem;
+  }
 
-.markdown ::v-deep ol {
-  padding-left: 1.2em;
-  list-style-type: decimal;
-}
-.markdown ::v-deep p {
-  margin-top: 1.5rem;
-}
-.markdown ::v-deep h2 + p {
-  margin-top: 0.3rem;
-}
-.markdown ::v-deep h3 + p {
-  margin-top: 0.3rem;
-}
-.markdown ::v-deep code {
-  border-radius: 3px;
-  font-size: 0.9rem;
-  display: block;
-  overflow-x: auto;
-  background: #1d1f21;
-  color: #c5c8c6;
-  padding: 0.5em;
-}
+  ul {
+    padding-left: 1.2em;
+    list-style-type: disc;
+  }
 
-.markdown ::v-deep img {
-  max-width: 80%;
-  margin: 1.5rem auto;
+  ol {
+    padding-left: 1.2em;
+    list-style-type: decimal;
+  }
+
+  li {
+    margin: 0.4rem 0;
+    > p {
+      margin: 0;
+    }
+  }
+
+  blockquote {
+    margin: 1.4rem 0;
+    border-left: 3px solid #b3bfc7;
+    padding: 2px 0 2px 0.7em;
+    color: #626e77;
+    :first-child {
+      margin: 0;
+    }
+  }
+
+  h2 + p {
+    margin-top: 0.3rem;
+  }
+
+  h3 + p {
+    margin-top: 0.3rem;
+  }
+
+  code {
+    border-radius: 3px;
+    font-size: 0.9rem;
+    display: block;
+    overflow-x: auto;
+    background: #1d1f21;
+    color: #c5c8c6;
+    padding: 0.5em;
+  }
+
+  img {
+    max-width: 80%;
+    margin: 1.5rem auto;
+  }
 }
 </style>

--- a/app/components/ProfileEditor.vue
+++ b/app/components/ProfileEditor.vue
@@ -1,10 +1,13 @@
 <template>
-  <section class="dashboard__content">
+  <section class="dashboard__content dashboardEdit">
     <h1>Profile</h1>
+    <div class="dashboardEdit__head">
+      <div />
+      <div class="dashboardEdit__btn">
+        <button class="btn" @click="saveProfile">保存</button>
+      </div>
+    </div>
     <MarkdownEditor :plain-text="plainText" @input="setPlainText" />
-    <button class="dashboard__btn btn btn--center" @click="saveProfile">
-      保存
-    </button>
   </section>
 </template>
 

--- a/app/layouts/error.vue
+++ b/app/layouts/error.vue
@@ -2,7 +2,9 @@
   <div class="error">
     <PageTitle v-if="error">{{ error.message }}</PageTitle>
     <PageTitle v-else>エラーが発生しました</PageTitle>
-    <NuxtLink to="/" class="btn error__btn">トップへ戻る</NuxtLink>
+    <div>
+      <NuxtLink to="/" class="btn error__btn">トップへ戻る</NuxtLink>
+    </div>
   </div>
 </template>
 

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -11,7 +11,7 @@
         <button class="btn sign-in" @click="signIn()">Sign in</button>
       </template>
     </header>
-    <main v-if="isAuth" class="wrapper dashboard">
+    <main v-if="isAuth" class="dashboard">
       <nav v-if="!$route.params.article" class="dashboard__nav">
         <NuxtLink
           to="/dashboard/profile"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5466,9 +5466,12 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001170",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz",
-      "integrity": "sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA=="
+      "version": "1.0.30001260",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001260.tgz",
+      "integrity": "sha512-Fhjc/k8725ItmrvW5QomzxLeojewxvqiYCKeFcfFEhut28IVLdpHU19dneOmltZQIE5HNbawj1HYD+1f2bM1Dg==",
+      "requires": {
+        "nanocolors": "^0.1.0"
+      }
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -14650,6 +14653,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "optional": true
+    },
+    "nanocolors": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.1.12.tgz",
+      "integrity": "sha512-2nMHqg1x5PU+unxX7PGY7AuYxl2qDx7PSrTRjizr8sxdd3l/3hBuWWaki62qmtYm2U5i4Z5E7GbjlyDFhs9/EQ=="
     },
     "nanoid": {
       "version": "3.1.20",


### PR DESCRIPTION
# 変更点
- マークダウンエディタの左右の余白を縮小
- ボタン類を画面上部に移動
- ボタンのスタイルをinline-flexに変更
- markdownのプレビューから不要なスクロールバーを非表示

# 修正
- dashboardの記事一覧の並び順を作成日順に修正
- エラー画面のボタンの表示崩れ