### PR TITLE
perf: バンドルサイズとpayloadの無駄な先読みを削減

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,14 @@ import { generateRoutes } from './routes'
 export default defineNuxtConfig({
   experimental: {
     componentIslands: true,
+    defaults: {
+      // NuxtLinkのprefetchを可視時(visibility)からホバー/フォーカス時(interaction)に変更する。
+      // デフォルトでは一覧ページでリンクが画面に入った時点で全記事のpayload.jsonが
+      // 先読みされてしまい無駄な通信が発生するため、クリック意図が見えた時のみ先読みする。
+      nuxtLink: {
+        prefetchOn: { visibility: false, interaction: true },
+      },
+    },
   },
 
   routeRules: {
@@ -55,15 +63,6 @@ export default defineNuxtConfig({
       preprocessorOptions: {
         scss: {
           additionalData: '@use "@/assets/style/variables.scss" as *;',
-        },
-      },
-    },
-    build: {
-      minify: false,
-      rollupOptions: {
-        preserveEntrySignatures: 'strict',
-        output: {
-          preserveModules: true,
         },
       },
     },


### PR DESCRIPTION
- vite.build の minify:false / preserveModules:true / preserveEntrySignatures:'strict'
  を削除。バンドル解析用に追加されていた設定が残っており、全モジュールが個別の
  JSファイルとして出力され大量のmodulepreloadが発生していた。
  通常のチャンク分割とminifyを有効化することで以下を改善:
    - _nuxt 合計: 5.2M → 1.7M
    - JSファイル数: 630 → 29
    - トップページの modulepreload: 256 → 11
    - index.html: 27KB → 8.9KB
- NuxtLink の prefetchOn を visibility から interaction へ変更。
  一覧ページでリンクが画面内に入っただけで全記事の payload.json が先読みされて
  いたのを、ホバー/フォーカス時のみ先読みするようにし無駄な通信を削減。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Rks6abC9UQCZ4CEd3epz44