### PR TITLE
ページ切り替え時にスクロール位置が先頭に戻らない問題を修正

### DIFF
--- a/app/components/Article/ArticleList.vue
+++ b/app/components/Article/ArticleList.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 
 import { useRoute } from '#app'
 import ArticleItem from '@/components/Article/ArticleItem.vue'
@@ -45,9 +45,10 @@ const paginatedArticles = computed(() => {
   return articles.value?.slice(start, start + PER_PAGE) ?? []
 })
 
-const onPageChange = (page: number) => {
+const onPageChange = async (page: number) => {
   currentPage.value = page
-  // ページ切り替え後は一覧の先頭までスクロールする
+  // 再描画でスムーズスクロールが中断されるため、DOM更新を待ってから一覧の先頭へスクロールする
+  await nextTick()
   listRef.value?.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 </script>


### PR DESCRIPTION
## 概要

PR #386（ページネーション）のフォローアップです。#386 がスクロール修正の push 前にマージされたため、この修正が `develop` に取り込まれていませんでした。本 PR で取り込みます。

## 変更内容
ページ切り替え時にスクロール位置が一覧の先頭に戻らない問題を修正しました。

`currentPage` 更新直後（DOM 再描画の前）に `scrollIntoView` を呼んでいたため、リストの再描画でスムーズスクロールが中断されていました。`nextTick()` で DOM 更新を待ってからスクロールするよう変更しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDgCvd2LG8Y6yKcWK5XHur)_