### PR TITLE
perf: index記事ページのmarkdown変換をビルド時に移しクライアント依存を分離

### DIFF
--- a/app/components/Article/ArticleView.vue
+++ b/app/components/Article/ArticleView.vue
@@ -43,11 +43,10 @@
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
 
-import { useRoute, useRuntimeConfig, useHead, createError } from '#app'
+import { useRoute, useRuntimeConfig, useHead, createError, useAsyncData } from '#app'
 import MarkdownPreview from '@/components/Article/MarkdownPreview.vue'
 import { useArticle } from '@/composables/useArticle'
 import Day from '@/utils/day'
-import { convertMarkdownTextToHTML, getHeadings } from '@/utils/markdown'
 
 const { params, path } = useRoute()
 const { article } = await useArticle(params.article as string)
@@ -86,8 +85,25 @@ onMounted(() => {
   }
 })
 
-const htmlText = await convertMarkdownTextToHTML(article.value?.text || '')
-const toc = computed(() => getHeadings(article.value?.text || ''))
+// markdown変換ライブラリ(remark/rehype/highlight.js, 計~570KB)はサイズが大きいため、
+// 動的importでクライアントバンドルから分離する。記事ページはプリレンダされるため、
+// 変換はビルド時(サーバー)に実行され、結果はpayloadにキャッシュされる。
+// クライアントのhydration時はキャッシュを読むだけでハンドラは再実行されず、
+// 変換ライブラリのチャンクもフェッチされない。
+const { data: rendered } = await useAsyncData(
+  `article-rendered-${article.value?.id}`,
+  async () => {
+    const { convertMarkdownTextToHTML, getHeadings } = await import('@/utils/markdown')
+    const text = article.value?.text || ''
+    return {
+      htmlText: await convertMarkdownTextToHTML(text),
+      toc: getHeadings(text),
+    }
+  },
+)
+
+const htmlText = computed(() => rendered.value?.htmlText || '')
+const toc = computed(() => rendered.value?.toc || [])
 
 const releaseDate = computed(() => Day.getDate(article.value?.releaseDate || 0, 'YYYY-MM-DD'))
 const updatedDate = computed(() => {


### PR DESCRIPTION
## 概要

dashboard 依存分離の調査中に判明した、**公開(index)記事ページに remark/rehype/highlight.js（計 ~570KB）が配信されている問題**への対応です。
（PR #396 の firebase/functions 分離とは別スコープのため、別 PR として切り出しました）

## 背景

`ArticleView.vue`（公開記事ページ）が、markdown→HTML 変換と目次生成を**クライアント側で実行**していました：

```ts
const htmlText = await convertMarkdownTextToHTML(article.value?.text || '')
const toc = computed(() => getHeadings(article.value?.text || ''))
```

`@/utils/markdown` を静的 import しているため、remark / rehype / unified / highlight.js 一式（記事ページのチャンク `BnpqvAsS.js` 481KB + `DJlaIgGj.js` 92KB）がリーダー全員に配信されていました。記事ページは**プリレンダされている**ため、この変換はビルド時に確定でき、クライアント実行は冗長です。

## 変更内容

`ArticleView.vue` の markdown 変換を `useAsyncData` + **動的 import** に変更：

```ts
const { data: rendered } = await useAsyncData(
  `article-rendered-${article.value?.id}`,
  async () => {
    const { convertMarkdownTextToHTML, getHeadings } = await import('@/utils/markdown')
    const text = article.value?.text || ''
    return { htmlText: await convertMarkdownTextToHTML(text), toc: getHeadings(text) }
  },
)
const htmlText = computed(() => rendered.value?.htmlText || '')
const toc = computed(() => rendered.value?.toc || [])
```

- プリレンダ時（サーバー）に変換を実行し、結果を payload にキャッシュ
- hydration 時はキャッシュを読むだけでハンドラは再実行されない → 変換ライブラリのチャンクもフェッチされない
- 静的 import を除去したため、変換ライブラリは記事ページのメインチャンクに含まれなくなる

## 検証（`nuxi build` + プリレンダ出力）

- 記事ページ HTML が読み込む全 JS チャンクで markdown 実装トークン（remark-parse / rehype-highlight / micromark / mdast-util）が **0 件**（変更前は `BnpqvAsS.js`+`DJlaIgGj.js` 計 ~570KB をロード）
- 変換済み記事 HTML（`class="markdown"` と id 付き見出し）・目次がプリレンダ HTML に埋め込まれていることを確認
- 変換結果が `_payload.json` にキャッシュされていることを確認
- markdown 変換ライブラリは独立した動的チャンク（記事 HTML からは未参照）に分離
- `eslint app/components/Article/ArticleView.vue` 通過

> 補足: payload に変換済み HTML が含まれる分だけ payload は増えますが、gzip 後で ~570KB の JS 配信・パースコスト削減の方が大きく、ネットでリーダー体験は改善します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6kB3WJrnAvYikGR7ZxkV7)_