### PR TITLE
記事内の単独行リンクをOGPカード表示する(記事ページ)

### DIFF
--- a/app/components/Article/ArticleView.vue
+++ b/app/components/Article/ArticleView.vue
@@ -96,7 +96,10 @@ const { data: rendered } = await useAsyncData(
     const { convertMarkdownTextToHTML, getHeadings } = await import('@/utils/markdown')
     const text = article.value?.text || ''
     return {
-      htmlText: await convertMarkdownTextToHTML(text),
+      // ogp: true は記事内の単独行リンクをOGPカードに変換する。
+      // この変換はprerender時(Node)に実行され結果はpayloadにキャッシュされるため、
+      // ブラウザ側で外部URLへのfetch(CORS)は発生しない。
+      htmlText: await convertMarkdownTextToHTML(text, { ogp: true }),
       toc: getHeadings(text),
     }
   },

--- a/app/components/Article/MarkdownPreview.vue
+++ b/app/components/Article/MarkdownPreview.vue
@@ -35,6 +35,83 @@ export default defineComponent({
     }
   }
 
+  // 単独行リンクから生成されるOGPカード
+  & a.ogpCard {
+    display: flex;
+    align-items: stretch;
+    margin: 1.5rem 0;
+    border: 1px solid var(--lightBlack);
+    border-radius: 8px;
+    overflow: hidden;
+    color: inherit;
+    text-decoration: none;
+    word-break: normal;
+    transition: 0.3s;
+    &:hover {
+      text-decoration: none;
+      opacity: 0.7;
+    }
+  }
+
+  .ogpCard__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    flex: 1;
+    min-width: 0;
+    padding: 0.9rem 1.1rem;
+  }
+
+  .ogpCard__title {
+    font-weight: 700;
+    line-height: 1.4;
+    // 2行で省略
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+
+  .ogpCard__desc {
+    font-size: 0.85rem;
+    color: var(--gray);
+    line-height: 1.5;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+
+  .ogpCard__site {
+    font-size: 0.8rem;
+    color: var(--gray);
+  }
+
+  .ogpCard__thumb {
+    flex-shrink: 0;
+    width: 200px;
+    background: var(--lightBlack);
+
+    img {
+      width: 100%;
+      height: 100%;
+      max-height: none;
+      margin: 0;
+      object-fit: cover;
+    }
+  }
+
+  @media screen and (max-width: $sm) {
+    & a.ogpCard {
+      flex-direction: column-reverse;
+    }
+
+    .ogpCard__thumb {
+      width: 100%;
+      aspect-ratio: 1200 / 630;
+    }
+  }
+
   h1 {
     margin-top: 2em;
     border-bottom: 1px solid #ddd;

--- a/app/utils/markdown.spec.ts
+++ b/app/utils/markdown.spec.ts
@@ -1,3 +1,5 @@
+import { afterEach, vi } from 'vitest'
+
 import { convertMarkdownTextToHTML, getHeadings } from '@/utils/markdown'
 
 describe('markdown', () => {
@@ -24,6 +26,71 @@ describe('markdown', () => {
       '<img src="https://staging-konkarin-photo.web.app/HomeImg.jpg" alt="Home image">',
     )
     expect(html).toContain(`<code>console.log(hoge)</code>`)
+  })
+
+  describe('OGPカード変換 (ogpオプション)', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    // OGPメタ情報を含むHTMLを返すfetchのモックを設定する
+    const stubFetch = (html: string, ok = true) => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok,
+          headers: { get: () => 'text/html; charset=utf-8' },
+          text: async () => html,
+        }),
+      )
+    }
+
+    test('単独行のリンクはOGPカードに変換される', async () => {
+      stubFetch(`
+        <html><head>
+          <meta property="og:title" content="サンプルタイトル" />
+          <meta property="og:description" content="サンプル説明" />
+          <meta property="og:image" content="https://example.com/ogp.png" />
+          <meta property="og:site_name" content="Example" />
+        </head><body></body></html>
+      `)
+
+      const html = await convertMarkdownTextToHTML('https://example.com/article\n', { ogp: true })
+
+      expect(html).toContain('class="ogpCard"')
+      expect(html).toContain('href="https://example.com/article"')
+      expect(html).toContain('サンプルタイトル')
+      expect(html).toContain('サンプル説明')
+      expect(html).toContain('https://example.com/ogp.png')
+    })
+
+    test('ogpオプションが無い場合は通常のリンクのまま', async () => {
+      stubFetch('<html></html>')
+
+      const html = await convertMarkdownTextToHTML('https://example.com/article\n')
+
+      expect(html).not.toContain('ogpCard')
+      expect(html).toContain('<a href="https://example.com/article">')
+      expect(fetch).not.toHaveBeenCalled()
+    })
+
+    test('文言付きリンクはカード化しない', async () => {
+      stubFetch('<html><head><meta property="og:title" content="t" /></head></html>')
+
+      const html = await convertMarkdownTextToHTML('[ラベル](https://example.com)\n', { ogp: true })
+
+      expect(html).not.toContain('ogpCard')
+      expect(html).toContain('<a href="https://example.com">ラベル</a>')
+    })
+
+    test('OGP取得に失敗した場合は通常のリンクにフォールバックする', async () => {
+      stubFetch('', false)
+
+      const html = await convertMarkdownTextToHTML('https://example.com/article\n', { ogp: true })
+
+      expect(html).not.toContain('ogpCard')
+      expect(html).toContain('<a href="https://example.com/article">')
+    })
   })
 
   test('getHeadings extracts headings from markdown', () => {

--- a/app/utils/markdown.ts
+++ b/app/utils/markdown.ts
@@ -1,4 +1,4 @@
-import type { Root as HastRoot, ElementContent } from 'hast'
+import type { Root as HastRoot, Element, ElementContent } from 'hast'
 import type { Root as MdastRoot, Heading as MdastHeading } from 'mdast'
 import { toString } from 'mdast-util-to-string'
 import highlight from 'rehype-highlight'
@@ -12,6 +12,8 @@ import rehype from 'remark-rehype'
 import remarkStringify from 'remark-stringify'
 import { unified } from 'unified'
 import { visit } from 'unist-util-visit'
+
+import { fetchOgp, type OgpData } from '@/utils/ogp'
 
 interface Heading {
   text: string
@@ -47,13 +49,167 @@ const rehypeAddHeadingIds = () => {
   }
 }
 
-export const convertMarkdownTextToHTML = async (markdownText: string) => {
-  const hast = await unified()
+/**
+ * 単独行のリンク(リンクだけの段落)かどうか判定し、対象ならそのa要素を返す。
+ * markdownでURLを単独行に書くと `<p><a href="url">url</a></p>` になるため、
+ * 「子がa要素1つだけ」かつ「リンク文字列がhrefと一致(=ベタ貼りURL)」のものを対象とする。
+ * `[ラベル](url)` のような文言付きリンクはカード化しない。
+ */
+const getBareLinkAnchor = (paragraph: Element): Element | null => {
+  const children = paragraph.children.filter(
+    (child) => !(child.type === 'text' && child.value.trim() === ''),
+  )
+  if (children.length !== 1) return null
+
+  const anchor = children[0]
+  if (anchor == null || anchor.type !== 'element' || anchor.tagName !== 'a') return null
+
+  const href = anchor.properties?.href
+  if (typeof href !== 'string' || href === '') return null
+
+  const text = anchor.children
+    .map((child) => (child.type === 'text' ? child.value : ''))
+    .join('')
+    .trim()
+  if (text !== href) return null
+
+  return anchor
+}
+
+/**
+ * OGPカードのhast要素を生成する。
+ * エディタのNodeViewと見た目を揃えられるよう .ogpCard 系のクラスで構造化する。
+ */
+const buildOgpCardNode = (href: string, ogp: OgpData): Element => {
+  const body: ElementContent[] = [
+    {
+      type: 'element',
+      tagName: 'span',
+      properties: { className: ['ogpCard__title'] },
+      children: [{ type: 'text', value: ogp.title || href }],
+    },
+  ]
+
+  if (ogp.description) {
+    body.push({
+      type: 'element',
+      tagName: 'span',
+      properties: { className: ['ogpCard__desc'] },
+      children: [{ type: 'text', value: ogp.description }],
+    })
+  }
+
+  let siteLabel = ogp.siteName
+  if (!siteLabel) {
+    try {
+      siteLabel = new URL(href).hostname
+    } catch {
+      siteLabel = href
+    }
+  }
+  body.push({
+    type: 'element',
+    tagName: 'span',
+    properties: { className: ['ogpCard__site'] },
+    children: [{ type: 'text', value: siteLabel }],
+  })
+
+  const children: ElementContent[] = [
+    {
+      type: 'element',
+      tagName: 'span',
+      properties: { className: ['ogpCard__body'] },
+      children: body,
+    },
+  ]
+
+  if (ogp.image) {
+    children.unshift({
+      type: 'element',
+      tagName: 'span',
+      properties: { className: ['ogpCard__thumb'] },
+      children: [
+        {
+          type: 'element',
+          tagName: 'img',
+          properties: { src: ogp.image, alt: '', loading: 'lazy' },
+          children: [],
+        },
+      ],
+    })
+  }
+
+  return {
+    type: 'element',
+    tagName: 'a',
+    properties: {
+      href,
+      className: ['ogpCard'],
+      target: '_blank',
+      rel: ['noopener', 'noreferrer'],
+    },
+    children,
+  }
+}
+
+/**
+ * 単独行のリンクをOGPカードに変換するrehypeプラグイン。
+ * OGP取得はネットワークI/Oを伴うため、ビルド時(prerender)のみ有効にすること。
+ * 取得失敗・OGP情報なしの場合は元のリンクのまま据え置く。
+ */
+const rehypeOgpCard = () => {
+  return async (tree: HastRoot) => {
+    const targets: { parent: { children: ElementContent[] }; index: number; href: string }[] = []
+
+    visit(tree, 'element', (node, index, parent) => {
+      if (node.tagName !== 'p' || parent == null || index == null) return
+      const anchor = getBareLinkAnchor(node)
+      if (anchor) {
+        targets.push({
+          parent: parent as { children: ElementContent[] },
+          index,
+          href: anchor.properties!.href as string,
+        })
+      }
+    })
+
+    if (targets.length === 0) return
+
+    // 外部サイトへのリクエストはまとめて並列で取得する
+    const results = await Promise.all(
+      targets.map(async (target) => ({ ...target, ogp: await fetchOgp(target.href) })),
+    )
+
+    for (const { parent, index, href, ogp } of results) {
+      // 取得失敗、もしくはタイトル/画像どちらも無い場合は通常リンクのまま
+      if (!ogp || (!ogp.title && !ogp.image)) continue
+      // カードはp要素と1対1で置換するためindexのズレは発生しない
+      parent.children[index] = buildOgpCardNode(href, ogp)
+    }
+  }
+}
+
+interface ConvertOptions {
+  // 単独行のリンクをOGPカードに変換する(ビルド時のみ。ブラウザではCORSで失敗する)
+  ogp?: boolean
+}
+
+export const convertMarkdownTextToHTML = async (
+  markdownText: string,
+  options: ConvertOptions = {},
+) => {
+  const processor = unified()
     .use(parse)
     .use(gfm)
     .use(breaks)
     .use(rehype)
     .use(rehypeAddHeadingIds)
+
+  if (options.ogp) {
+    processor.use(rehypeOgpCard)
+  }
+
+  const hast = await processor
     .use(stringify)
     .use(highlight)
     .process(markdownText)

--- a/app/utils/ogp.ts
+++ b/app/utils/ogp.ts
@@ -1,0 +1,92 @@
+import type { Root as HastRoot } from 'hast'
+import rehypeParse from 'rehype-parse'
+import { unified } from 'unified'
+import { visit } from 'unist-util-visit'
+
+export interface OgpData {
+  url: string
+  title?: string
+  description?: string
+  image?: string
+  siteName?: string
+}
+
+/**
+ * URLからOGPメタ情報を取得する。
+ * Nuxtのprerender(nuxt generate)時にビルド側(Node)で実行されることを想定しているため、
+ * ブラウザ環境(CORS)では利用しないこと。
+ * 取得に失敗した場合はnullを返し、呼び出し側で通常のリンクにフォールバックする。
+ */
+export const fetchOgp = async (url: string, timeoutMs = 5000): Promise<OgpData | null> => {
+  try {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        // OGPを返さないサイト対策で一般的なUAを送る
+        'user-agent':
+          'Mozilla/5.0 (compatible; konkarin-photo-ogp/1.0; +https://konkarin.photo)',
+      },
+    }).finally(() => clearTimeout(timer))
+
+    if (!res.ok) return null
+
+    const contentType = res.headers.get('content-type') || ''
+    if (!contentType.includes('text/html')) return null
+
+    const html = await res.text()
+    return parseOgp(html, url)
+  } catch (e) {
+    console.error(`Failed to fetch OGP for ${url}:`, e)
+    return null
+  }
+}
+
+/**
+ * HTML文字列からOGP情報をパースする。
+ * og:* を優先し、無い場合は<title>やmeta descriptionにフォールバックする。
+ */
+const parseOgp = (html: string, url: string): OgpData => {
+  const tree = unified().use(rehypeParse).parse(html) as HastRoot
+
+  const meta: Record<string, string> = {}
+  let titleTag = ''
+
+  visit(tree, 'element', (node) => {
+    if (node.tagName === 'meta') {
+      const key = (node.properties?.property ?? node.properties?.name) as string | undefined
+      const content = node.properties?.content as string | undefined
+      if (key && content && meta[key.toLowerCase()] === undefined) {
+        meta[key.toLowerCase()] = content
+      }
+    }
+
+    if (node.tagName === 'title' && titleTag === '') {
+      const text = node.children.find((child) => child.type === 'text')
+      if (text && text.type === 'text') {
+        titleTag = text.value.trim()
+      }
+    }
+  })
+
+  // og:imageは相対URLのことがあるためページURLを基準に絶対URL化する
+  const rawImage = meta['og:image'] || meta['og:image:url']
+  let image: string | undefined
+  if (rawImage) {
+    try {
+      image = new URL(rawImage, url).href
+    } catch {
+      image = undefined
+    }
+  }
+
+  return {
+    url,
+    title: meta['og:title'] || titleTag || undefined,
+    description: meta['og:description'] || meta['description'] || undefined,
+    image,
+    siteName: meta['og:site_name'] || undefined,
+  }
+}


### PR DESCRIPTION
## 概要

記事内でURLを単独行に書いた場合、ビルド時(prerender)にOGPを取得してカード表示するようにしました。エディタページ側は今回対象外です。

## 変更内容

| ファイル | 内容 |
|---|---|
| `app/utils/ogp.ts`（新規） | URLからOGPメタ情報を取得・パースするユーティリティ。タイムアウト付き、`og:*`優先で`<title>`/meta descriptionにフォールバック、`og:image`は絶対URL化 |
| `app/utils/markdown.ts` | 単独行リンクをOGPカードに変換するrehypeプラグインを追加。`convertMarkdownTextToHTML(text, { ogp: true })`のオプトイン方式。取得失敗時は通常リンクにフォールバック |
| `app/components/Article/ArticleView.vue` | 記事ビューで`ogp`オプションを有効化 |
| `app/components/Article/MarkdownPreview.vue` | OGPカードのスタイルを追加（モバイルは縦並び） |

## 設計のポイント

- **表現**: 単独行のベタ貼りURL（リンク文字列＝href）だけをカード化。`[ラベル](url)`や文中インラインのリンクは通常リンクのまま。Markdown・保存スキーマは無変更。
- **取得タイミング**: `ArticleView`の`useAsyncData`はprerender時(Node)のみ実行されpayloadにキャッシュされるため、ブラウザでの外部fetch(CORS)は発生しない。記事詳細ページが`generateRoutes`でプリレンダ対象なことも確認済み。
- **オプトイン**: `convertMarkdownTextToHTML`はエディタ側（読み込み・ペースト）でも使われるため、デフォルト挙動は変えず記事ビューだけ有効化。
- **堅牢性**: 取得失敗・OGP情報なしは通常リンクにフォールバック。複数URLは並列取得。

## 補足（既知の制約）

- キャッシュなしのため、毎ビルドで全記事のURLを再取得します。記事数増加でビルドが重くなる／外部サイトへの連打が気になる場合はキャッシュ追加を検討。
- OGPの鮮度は「次のビルドまで固定」（記事を編集しないと再ビルドされない仕様）。鮮度を上げたい場合は定期リビルド等を別途検討。
- エディタページ側のOGP表示（Tiptapカスタムノード + 取得エンドポイント）は未着手。

## テスト

- 既存テスト + 追加4ケース（カード化／オプトインなし／文言付きリンク／取得失敗フォールバック）すべてパス（計7件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JRduVGJPoCVyXhtySWCeW

---
_Generated by [Claude Code](https://claude.ai/code/session_018JRduVGJPoCVyXhtySWCeW)_