### PR TITLE
fix: typecheckの@types/uuid型定義エラーを修正

### DIFF
--- a/app/components/Dashboard/DashboardHeaderNav.vue
+++ b/app/components/Dashboard/DashboardHeaderNav.vue
@@ -5,20 +5,26 @@
       <NuxtLink
         to="/dashboard/photos"
         class="headerNav__item"
-        :class="{ 'headerNav__item--active': $route.path === '/dashboard/photos' }"
+        :class="{ 'headerNav__item--active': route.path === '/dashboard/photos' }"
       >
         Photos
       </NuxtLink>
       <NuxtLink
         to="/dashboard/articles"
         class="headerNav__item"
-        :class="{ 'headerNav__item--active': $route.path.includes('/dashboard/articles') }"
+        :class="{ 'headerNav__item--active': route.path.includes('/dashboard/articles') }"
       >
         Blog
       </NuxtLink>
     </div>
   </nav>
 </template>
+
+<script setup lang="ts">
+import { useRoute } from '#app'
+
+const route = useRoute()
+</script>
 
 <style lang="scss" scoped>
 .headerNav {

--- a/app/components/HeaderNav.vue
+++ b/app/components/HeaderNav.vue
@@ -5,27 +5,33 @@
       <NuxtLink
         to="/"
         class="headerNav__item"
-        :class="{ 'headerNav__item--active': $route.path === '/' }"
+        :class="{ 'headerNav__item--active': route.path === '/' }"
       >
         Home
       </NuxtLink>
       <NuxtLink
         to="/photos"
         class="headerNav__item"
-        :class="{ 'headerNav__item--active': $route.path === '/photos' }"
+        :class="{ 'headerNav__item--active': route.path === '/photos' }"
       >
         Photos
       </NuxtLink>
       <NuxtLink
         to="/articles"
         class="headerNav__item"
-        :class="{ 'headerNav__item--active': $route.path.includes('/articles') }"
+        :class="{ 'headerNav__item--active': route.path.includes('/articles') }"
       >
         Blog
       </NuxtLink>
     </div>
   </nav>
 </template>
+
+<script setup lang="ts">
+import { useRoute } from '#app'
+
+const route = useRoute()
+</script>
 
 <style lang="scss" scoped>
 .headerNav {

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -5,7 +5,7 @@
     </div>
     <template v-if="isAuth">
       <header>
-        <DashboardHeaderNav v-if="!$route.params.article" />
+        <DashboardHeaderNav v-if="!route.params.article" />
       </header>
       <main class="dashboard">
         <NuxtPage />
@@ -21,12 +21,15 @@
 import { getAuth, GoogleAuthProvider, signInWithPopup } from '@firebase/auth'
 import { ref, provide, onMounted } from 'vue'
 
+import { useRoute } from '#app'
 import BaseButton from '@/components/BaseButton.vue'
 import DashboardHeaderNav from '@/components/Dashboard/DashboardHeaderNav.vue'
 import Loader from '@/components/Loader.vue'
 import ToastProvider from '@/components/Toast/ToastProvider.vue'
 import { useAuth, AUTH_KEY } from '@/composables/useAuth'
 import { useRouterCommand } from '@/composables/useCommand'
+
+const route = useRoute()
 
 const isLoading = ref(true)
 const isUploading = ref(false)

--- a/app/pages/index/tags/[tag].vue
+++ b/app/pages/index/tags/[tag].vue
@@ -1,6 +1,6 @@
 <template>
   <main class="wrapper">
-    <PageTitle>タグ: {{ $route.params.tag }}</PageTitle>
+    <PageTitle>タグ: {{ params.tag }}</PageTitle>
     <div class="article">
       <ArticleList />
       <ArticlesSideMenu />

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
       "devDependencies": {
         "@nuxtjs/sitemap": "7.5.0",
         "@types/node": "25.3.3",
-        "@types/uuid": "11.0.0",
         "@vitest/eslint-plugin": "1.6.9",
         "@vue/eslint-config-prettier": "10.2.0",
         "@vue/eslint-config-typescript": "14.6.0",
@@ -7912,17 +7911,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
-      }
     },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
@@ -32051,15 +32039,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    },
-    "@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "dev": true,
-      "requires": {
-        "uuid": "*"
-      }
     },
     "@types/whatwg-mimetype": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "devDependencies": {
     "@nuxtjs/sitemap": "7.5.0",
     "@types/node": "25.3.3",
-    "@types/uuid": "11.0.0",
     "@vitest/eslint-plugin": "1.6.9",
     "@vue/eslint-config-prettier": "10.2.0",
     "@vue/eslint-config-typescript": "14.6.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./.nuxt/tsconfig.json",
   "compilerOptions": {
-    "types": ["@types/node", "vitest/globals", "@types/uuid"]
+    "types": ["@types/node", "vitest/globals"]
   },
   "exclude": ["node_modules", "functions"]
 }


### PR DESCRIPTION
uuid 13.0.0は自前の型定義を同梱しており、@types/uuid 11.0.0は
型定義エントリポイントを持たないスタブパッケージになっている。
tsconfig.jsonのtypes配列に明示指定していたためTS2688エラーが
発生していたので、@types/uuidの指定と不要なdevDependencyを削除した。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TzPo6YGfgx488Y4nvRfPcE